### PR TITLE
feat: add integration testing with reporters-validator

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -57,6 +57,52 @@ jobs:
         working-directory: example
         run: ./vendor/bin/pest --colors=always
 
+  integration-test:
+    runs-on: ubuntu-latest
+    needs: tests
+    name: Integration Test
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+          extensions: mbstring, json, fileinfo
+          coverage: none
+
+      - name: Install main package dependencies
+        run: composer update --prefer-dist --no-progress
+
+      - name: Install example dependencies
+        working-directory: example
+        run: composer update --prefer-dist --no-progress
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install reporters-validator
+        run: pip install git+https://github.com/qase-tms/reporters-validator.git
+
+      - name: Download report schemas
+        run: git clone --depth 1 https://github.com/qase-tms/specs.git /tmp/specs
+
+      - name: Validate Pest reporter
+        working-directory: example
+        run: |
+          QASE_MODE=report \
+          QASE_REPORT_CONNECTION_PATH=${{ github.workspace }}/build/report \
+          ./vendor/bin/pest --colors=always || true
+
+          reporters-validator validate \
+            --report-dir ${{ github.workspace }}/build/report \
+            --expected ${{ github.workspace }}/expected/pest-examples.yaml \
+            --schema-dir /tmp/specs/report/schemas
+
   code-style:
     runs-on: ubuntu-latest
     name: Code Style

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -53,9 +53,9 @@ jobs:
           composer require pestphp/pest:${{ matrix.pest }} --dev --no-update
           composer update --prefer-dist --no-progress
 
-      - name: Run tests
+      - name: Run example tests
         working-directory: example
-        run: ./vendor/bin/pest --colors=always
+        run: ./vendor/bin/pest --colors=always || true
 
   integration-test:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /vendor/
 /example/vendor/
 /example/build/
+/build/
 /docs/
 .phpunit.result.cache
 .phpunit.cache/

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
       "Tests\\": "tests/"
     }
   },
-  "version": "1.0.1",
+  "version": "1.0.2",
   "scripts": {
     "test": "pest"
   },

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
   "require": {
     "php": "^8.2",
     "phpunit/phpunit": "^10 || ^11 || ^12",
-    "qase/php-commons": "^2.1.13"
+    "qase/php-commons": "^2.1.17"
   },
   "require-dev": {
     "pestphp/pest": "^2.0 || ^3.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a419c25406d3b4c056b91f697eef3d9f",
+    "content-hash": "33c5cb75fd234fb9594595145299b157",
     "packages": [
         {
             "name": "brick/math",
@@ -1245,16 +1245,16 @@
         },
         {
             "name": "qase/php-commons",
-            "version": "2.1.13",
+            "version": "2.1.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/qase-tms/qase-php-commons.git",
-                "reference": "9a44ce480dd9a51575db6a978f306455a6c4bafd"
+                "reference": "b9e8b70419e0ba2a5645879b4c5af23bad0b9e54"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/qase-tms/qase-php-commons/zipball/9a44ce480dd9a51575db6a978f306455a6c4bafd",
-                "reference": "9a44ce480dd9a51575db6a978f306455a6c4bafd",
+                "url": "https://api.github.com/repos/qase-tms/qase-php-commons/zipball/b9e8b70419e0ba2a5645879b4c5af23bad0b9e54",
+                "reference": "b9e8b70419e0ba2a5645879b4c5af23bad0b9e54",
                 "shasum": ""
             },
             "require": {
@@ -1294,9 +1294,9 @@
             ],
             "support": {
                 "issues": "https://github.com/qase-tms/qase-php-commons/issues",
-                "source": "https://github.com/qase-tms/qase-php-commons/tree/v2.1.13"
+                "source": "https://github.com/qase-tms/qase-php-commons/tree/v2.1.17"
             },
-            "time": "2026-02-05T19:04:00+00:00"
+            "time": "2026-04-06T12:01:38+00:00"
         },
         {
             "name": "qase/qase-api-client",

--- a/example/composer.lock
+++ b/example/composer.lock
@@ -102,16 +102,16 @@
         },
         {
             "name": "brick/math",
-            "version": "0.14.6",
+            "version": "0.14.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/brick/math.git",
-                "reference": "32498d5e1897e7642c0b961ace2df6d7dc9a3bc3"
+                "reference": "63422359a44b7f06cae63c3b429b59e8efcc0629"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/brick/math/zipball/32498d5e1897e7642c0b961ace2df6d7dc9a3bc3",
-                "reference": "32498d5e1897e7642c0b961ace2df6d7dc9a3bc3",
+                "url": "https://api.github.com/repos/brick/math/zipball/63422359a44b7f06cae63c3b429b59e8efcc0629",
+                "reference": "63422359a44b7f06cae63c3b429b59e8efcc0629",
                 "shasum": ""
             },
             "require": {
@@ -150,7 +150,7 @@
             ],
             "support": {
                 "issues": "https://github.com/brick/math/issues",
-                "source": "https://github.com/brick/math/tree/0.14.6"
+                "source": "https://github.com/brick/math/tree/0.14.8"
             },
             "funding": [
                 {
@@ -158,33 +158,33 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-02-05T07:59:58+00:00"
+            "time": "2026-02-10T14:33:43+00:00"
         },
         {
             "name": "doctrine/deprecations",
-            "version": "1.1.5",
+            "version": "1.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/deprecations.git",
-                "reference": "459c2f5dd3d6a4633d3b5f46ee2b1c40f57d3f38"
+                "reference": "d4fe3e6fd9bb9e72557a19674f44d8ac7db4c6ca"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/deprecations/zipball/459c2f5dd3d6a4633d3b5f46ee2b1c40f57d3f38",
-                "reference": "459c2f5dd3d6a4633d3b5f46ee2b1c40f57d3f38",
+                "url": "https://api.github.com/repos/doctrine/deprecations/zipball/d4fe3e6fd9bb9e72557a19674f44d8ac7db4c6ca",
+                "reference": "d4fe3e6fd9bb9e72557a19674f44d8ac7db4c6ca",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1 || ^8.0"
             },
             "conflict": {
-                "phpunit/phpunit": "<=7.5 || >=13"
+                "phpunit/phpunit": "<=7.5 || >=14"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^9 || ^12 || ^13",
-                "phpstan/phpstan": "1.4.10 || 2.1.11",
+                "doctrine/coding-standard": "^9 || ^12 || ^14",
+                "phpstan/phpstan": "1.4.10 || 2.1.30",
                 "phpstan/phpstan-phpunit": "^1.0 || ^2",
-                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.6 || ^10.5 || ^11.5 || ^12",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.6 || ^10.5 || ^11.5 || ^12.4 || ^13.0",
                 "psr/log": "^1 || ^2 || ^3"
             },
             "suggest": {
@@ -204,9 +204,9 @@
             "homepage": "https://www.doctrine-project.org/",
             "support": {
                 "issues": "https://github.com/doctrine/deprecations/issues",
-                "source": "https://github.com/doctrine/deprecations/tree/1.1.5"
+                "source": "https://github.com/doctrine/deprecations/tree/1.1.6"
             },
-            "time": "2025-04-07T20:06:18+00:00"
+            "time": "2026-02-07T07:09:04+00:00"
         },
         {
             "name": "fidry/cpu-core-counter",
@@ -551,16 +551,16 @@
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "2.8.0",
+            "version": "2.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "21dc724a0583619cd1652f673303492272778051"
+                "reference": "7d0ed42f28e42d61352a7a79de682e5e67fec884"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/21dc724a0583619cd1652f673303492272778051",
-                "reference": "21dc724a0583619cd1652f673303492272778051",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/7d0ed42f28e42d61352a7a79de682e5e67fec884",
+                "reference": "7d0ed42f28e42d61352a7a79de682e5e67fec884",
                 "shasum": ""
             },
             "require": {
@@ -576,6 +576,7 @@
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
                 "http-interop/http-factory-tests": "0.9.0",
+                "jshttp/mime-db": "1.54.0.1",
                 "phpunit/phpunit": "^8.5.44 || ^9.6.25"
             },
             "suggest": {
@@ -647,7 +648,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/2.8.0"
+                "source": "https://github.com/guzzle/psr7/tree/2.9.0"
             },
             "funding": [
                 {
@@ -663,7 +664,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-23T21:21:41+00:00"
+            "time": "2026-03-10T16:41:02+00:00"
         },
         {
             "name": "jean85/pretty-package-versions",
@@ -845,39 +846,36 @@
         },
         {
             "name": "nunomaduro/collision",
-            "version": "v8.8.3",
+            "version": "v8.9.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nunomaduro/collision.git",
-                "reference": "1dc9e88d105699d0fee8bb18890f41b274f6b4c4"
+                "reference": "6eb16883e74fd725ac64dbe81544c961ab448ba5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nunomaduro/collision/zipball/1dc9e88d105699d0fee8bb18890f41b274f6b4c4",
-                "reference": "1dc9e88d105699d0fee8bb18890f41b274f6b4c4",
+                "url": "https://api.github.com/repos/nunomaduro/collision/zipball/6eb16883e74fd725ac64dbe81544c961ab448ba5",
+                "reference": "6eb16883e74fd725ac64dbe81544c961ab448ba5",
                 "shasum": ""
             },
             "require": {
-                "filp/whoops": "^2.18.1",
-                "nunomaduro/termwind": "^2.3.1",
+                "filp/whoops": "^2.18.4",
+                "nunomaduro/termwind": "^2.4.0",
                 "php": "^8.2.0",
-                "symfony/console": "^7.3.0"
+                "symfony/console": "^7.4.8 || ^8.0.4"
             },
             "conflict": {
-                "laravel/framework": "<11.44.2 || >=13.0.0",
-                "phpunit/phpunit": "<11.5.15 || >=13.0.0"
+                "laravel/framework": "<11.48.0 || >=14.0.0",
+                "phpunit/phpunit": "<11.5.50 || >=14.0.0"
             },
             "require-dev": {
-                "brianium/paratest": "^7.8.3",
-                "larastan/larastan": "^3.4.2",
-                "laravel/framework": "^11.44.2 || ^12.18",
-                "laravel/pint": "^1.22.1",
-                "laravel/sail": "^1.43.1",
-                "laravel/sanctum": "^4.1.1",
-                "laravel/tinker": "^2.10.1",
-                "orchestra/testbench-core": "^9.12.0 || ^10.4",
-                "pestphp/pest": "^3.8.2 || ^4.0.0",
-                "sebastian/environment": "^7.2.1 || ^8.0"
+                "brianium/paratest": "^7.8.5",
+                "larastan/larastan": "^3.9.3",
+                "laravel/framework": "^11.48.0 || ^12.56.0 || ^13.2.0",
+                "laravel/pint": "^1.29.0",
+                "orchestra/testbench-core": "^9.12.0 || ^10.12.1 || ^11.0.0",
+                "pestphp/pest": "^3.8.5 || ^4.4.3 || ^5.0.0",
+                "sebastian/environment": "^7.2.1 || ^8.0.4 || ^9.0.0"
             },
             "type": "library",
             "extra": {
@@ -940,35 +938,35 @@
                     "type": "patreon"
                 }
             ],
-            "time": "2025-11-20T02:55:25+00:00"
+            "time": "2026-03-31T21:51:27+00:00"
         },
         {
             "name": "nunomaduro/termwind",
-            "version": "v2.3.3",
+            "version": "v2.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nunomaduro/termwind.git",
-                "reference": "6fb2a640ff502caace8e05fd7be3b503a7e1c017"
+                "reference": "712a31b768f5daea284c2169a7d227031001b9a8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nunomaduro/termwind/zipball/6fb2a640ff502caace8e05fd7be3b503a7e1c017",
-                "reference": "6fb2a640ff502caace8e05fd7be3b503a7e1c017",
+                "url": "https://api.github.com/repos/nunomaduro/termwind/zipball/712a31b768f5daea284c2169a7d227031001b9a8",
+                "reference": "712a31b768f5daea284c2169a7d227031001b9a8",
                 "shasum": ""
             },
             "require": {
                 "ext-mbstring": "*",
                 "php": "^8.2",
-                "symfony/console": "^7.3.6"
+                "symfony/console": "^7.4.4 || ^8.0.4"
             },
             "require-dev": {
-                "illuminate/console": "^11.46.1",
-                "laravel/pint": "^1.25.1",
+                "illuminate/console": "^11.47.0",
+                "laravel/pint": "^1.27.1",
                 "mockery/mockery": "^1.6.12",
-                "pestphp/pest": "^2.36.0 || ^3.8.4 || ^4.1.3",
+                "pestphp/pest": "^2.36.0 || ^3.8.4 || ^4.3.2",
                 "phpstan/phpstan": "^1.12.32",
                 "phpstan/phpstan-strict-rules": "^1.6.2",
-                "symfony/var-dumper": "^7.3.5",
+                "symfony/var-dumper": "^7.3.5 || ^8.0.4",
                 "thecodingmachine/phpstan-strict-rules": "^1.0.0"
             },
             "type": "library",
@@ -1000,7 +998,7 @@
                     "email": "enunomaduro@gmail.com"
                 }
             ],
-            "description": "Its like Tailwind CSS, but for the console.",
+            "description": "It's like Tailwind CSS, but for the console.",
             "keywords": [
                 "cli",
                 "console",
@@ -1011,7 +1009,7 @@
             ],
             "support": {
                 "issues": "https://github.com/nunomaduro/termwind/issues",
-                "source": "https://github.com/nunomaduro/termwind/tree/v2.3.3"
+                "source": "https://github.com/nunomaduro/termwind/tree/v2.4.0"
             },
             "funding": [
                 {
@@ -1027,26 +1025,26 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-11-20T02:34:59+00:00"
+            "time": "2026-02-16T23:10:27+00:00"
         },
         {
             "name": "pestphp/pest",
-            "version": "v3.8.5",
+            "version": "v3.8.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/pestphp/pest.git",
-                "reference": "7796630eafcfd1c02660cecdde3bc6984fbf01f4"
+                "reference": "8871a6f5ef1de8e7c8dee2a270991449a7b6af73"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/pestphp/pest/zipball/7796630eafcfd1c02660cecdde3bc6984fbf01f4",
-                "reference": "7796630eafcfd1c02660cecdde3bc6984fbf01f4",
+                "url": "https://api.github.com/repos/pestphp/pest/zipball/8871a6f5ef1de8e7c8dee2a270991449a7b6af73",
+                "reference": "8871a6f5ef1de8e7c8dee2a270991449a7b6af73",
                 "shasum": ""
             },
             "require": {
                 "brianium/paratest": "^7.8.5",
-                "nunomaduro/collision": "^8.8.3",
-                "nunomaduro/termwind": "^2.3.3",
+                "nunomaduro/collision": "^8.9.1",
+                "nunomaduro/termwind": "^2.4.0",
                 "pestphp/pest-plugin": "^3.0.0",
                 "pestphp/pest-plugin-arch": "^3.1.1",
                 "pestphp/pest-plugin-mutate": "^3.0.5",
@@ -1062,7 +1060,7 @@
             "require-dev": {
                 "pestphp/pest-dev-tools": "^3.4.0",
                 "pestphp/pest-plugin-type-coverage": "^3.6.1",
-                "symfony/process": "^7.4.4"
+                "symfony/process": "^7.4.5"
             },
             "bin": [
                 "bin/pest"
@@ -1127,7 +1125,7 @@
             ],
             "support": {
                 "issues": "https://github.com/pestphp/pest/issues",
-                "source": "https://github.com/pestphp/pest/tree/v3.8.5"
+                "source": "https://github.com/pestphp/pest/tree/v3.8.6"
             },
             "funding": [
                 {
@@ -1139,7 +1137,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-01-28T01:33:45+00:00"
+            "time": "2026-03-10T21:04:33+00:00"
         },
         {
             "name": "pestphp/pest-plugin",
@@ -1526,16 +1524,16 @@
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "6.0.1",
+            "version": "6.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "2f5cbed597cb261d1ea458f3da3a9ad32e670b1e"
+                "reference": "7bae67520aa9f5ecc506d646810bd40d9da54582"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/2f5cbed597cb261d1ea458f3da3a9ad32e670b1e",
-                "reference": "2f5cbed597cb261d1ea458f3da3a9ad32e670b1e",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/7bae67520aa9f5ecc506d646810bd40d9da54582",
+                "reference": "7bae67520aa9f5ecc506d646810bd40d9da54582",
                 "shasum": ""
             },
             "require": {
@@ -1585,9 +1583,9 @@
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
             "support": {
                 "issues": "https://github.com/phpDocumentor/ReflectionDocBlock/issues",
-                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/6.0.1"
+                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/6.0.3"
             },
-            "time": "2026-01-20T15:30:42+00:00"
+            "time": "2026-03-18T20:49:53+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
@@ -2466,16 +2464,16 @@
         },
         {
             "name": "qase/pest-reporter",
-            "version": "1.0.0",
+            "version": "1.0.1",
             "dist": {
                 "type": "path",
                 "url": "..",
-                "reference": "34d4d5d7e76b698c087bea8eb0611ce819e6f92a"
+                "reference": "e2d79d1523378836d0bfb0e48012f200d1d72ac7"
             },
             "require": {
                 "php": "^8.2",
                 "phpunit/phpunit": "^10 || ^11 || ^12",
-                "qase/php-commons": "^2.1.13"
+                "qase/php-commons": "^2.1.17"
             },
             "require-dev": {
                 "pestphp/pest": "^2.0 || ^3.0"
@@ -2525,16 +2523,16 @@
         },
         {
             "name": "qase/php-commons",
-            "version": "2.1.13",
+            "version": "2.1.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/qase-tms/qase-php-commons.git",
-                "reference": "9a44ce480dd9a51575db6a978f306455a6c4bafd"
+                "reference": "b9e8b70419e0ba2a5645879b4c5af23bad0b9e54"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/qase-tms/qase-php-commons/zipball/9a44ce480dd9a51575db6a978f306455a6c4bafd",
-                "reference": "9a44ce480dd9a51575db6a978f306455a6c4bafd",
+                "url": "https://api.github.com/repos/qase-tms/qase-php-commons/zipball/b9e8b70419e0ba2a5645879b4c5af23bad0b9e54",
+                "reference": "b9e8b70419e0ba2a5645879b4c5af23bad0b9e54",
                 "shasum": ""
             },
             "require": {
@@ -2574,22 +2572,22 @@
             ],
             "support": {
                 "issues": "https://github.com/qase-tms/qase-php-commons/issues",
-                "source": "https://github.com/qase-tms/qase-php-commons/tree/v2.1.13"
+                "source": "https://github.com/qase-tms/qase-php-commons/tree/v2.1.17"
             },
-            "time": "2026-02-05T19:04:00+00:00"
+            "time": "2026-04-06T12:01:38+00:00"
         },
         {
             "name": "qase/qase-api-client",
-            "version": "1.1.5",
+            "version": "1.1.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/qase-tms/qase-api-client.git",
-                "reference": "2a95fe3c8a09a3d733338cde79c3f97ce74ea6d2"
+                "reference": "edde038fcc858cd342eb900c076524798f635772"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/qase-tms/qase-api-client/zipball/2a95fe3c8a09a3d733338cde79c3f97ce74ea6d2",
-                "reference": "2a95fe3c8a09a3d733338cde79c3f97ce74ea6d2",
+                "url": "https://api.github.com/repos/qase-tms/qase-api-client/zipball/edde038fcc858cd342eb900c076524798f635772",
+                "reference": "edde038fcc858cd342eb900c076524798f635772",
                 "shasum": ""
             },
             "require": {
@@ -2630,22 +2628,22 @@
             ],
             "support": {
                 "issues": "https://github.com/qase-tms/qase-api-client/issues",
-                "source": "https://github.com/qase-tms/qase-api-client/tree/v1.1.5"
+                "source": "https://github.com/qase-tms/qase-api-client/tree/v1.1.10"
             },
-            "time": "2025-09-23T12:19:27+00:00"
+            "time": "2026-03-26T13:32:24+00:00"
         },
         {
             "name": "qase/qase-api-v2-client",
-            "version": "1.1.2",
+            "version": "1.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/qase-tms/qase-api-v2-client.git",
-                "reference": "1d70ae5efc88fdb24af60bd24e3f0352237ee86c"
+                "reference": "b4104e86440a4dd78de874caf0a6bcf4575e8be8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/qase-tms/qase-api-v2-client/zipball/1d70ae5efc88fdb24af60bd24e3f0352237ee86c",
-                "reference": "1d70ae5efc88fdb24af60bd24e3f0352237ee86c",
+                "url": "https://api.github.com/repos/qase-tms/qase-api-v2-client/zipball/b4104e86440a4dd78de874caf0a6bcf4575e8be8",
+                "reference": "b4104e86440a4dd78de874caf0a6bcf4575e8be8",
                 "shasum": ""
             },
             "require": {
@@ -2686,9 +2684,9 @@
             ],
             "support": {
                 "issues": "https://github.com/qase-tms/qase-api-v2-client/issues",
-                "source": "https://github.com/qase-tms/qase-api-v2-client/tree/v1.1.2"
+                "source": "https://github.com/qase-tms/qase-api-v2-client/tree/v1.1.4"
             },
-            "time": "2025-08-13T07:36:21+00:00"
+            "time": "2026-03-26T13:40:00+00:00"
         },
         {
             "name": "ralouphie/getallheaders",
@@ -3928,47 +3926,39 @@
         },
         {
             "name": "symfony/console",
-            "version": "v7.4.4",
+            "version": "v8.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "41e38717ac1dd7a46b6bda7d6a82af2d98a78894"
+                "reference": "5b66d385dc58f69652e56f78a4184615e3f2b7f7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/41e38717ac1dd7a46b6bda7d6a82af2d98a78894",
-                "reference": "41e38717ac1dd7a46b6bda7d6a82af2d98a78894",
+                "url": "https://api.github.com/repos/symfony/console/zipball/5b66d385dc58f69652e56f78a4184615e3f2b7f7",
+                "reference": "5b66d385dc58f69652e56f78a4184615e3f2b7f7",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2",
-                "symfony/deprecation-contracts": "^2.5|^3",
-                "symfony/polyfill-mbstring": "~1.0",
+                "php": ">=8.4",
+                "symfony/polyfill-mbstring": "^1.0",
                 "symfony/service-contracts": "^2.5|^3",
-                "symfony/string": "^7.2|^8.0"
-            },
-            "conflict": {
-                "symfony/dependency-injection": "<6.4",
-                "symfony/dotenv": "<6.4",
-                "symfony/event-dispatcher": "<6.4",
-                "symfony/lock": "<6.4",
-                "symfony/process": "<6.4"
+                "symfony/string": "^7.4|^8.0"
             },
             "provide": {
                 "psr/log-implementation": "1.0|2.0|3.0"
             },
             "require-dev": {
                 "psr/log": "^1|^2|^3",
-                "symfony/config": "^6.4|^7.0|^8.0",
-                "symfony/dependency-injection": "^6.4|^7.0|^8.0",
-                "symfony/event-dispatcher": "^6.4|^7.0|^8.0",
-                "symfony/http-foundation": "^6.4|^7.0|^8.0",
-                "symfony/http-kernel": "^6.4|^7.0|^8.0",
-                "symfony/lock": "^6.4|^7.0|^8.0",
-                "symfony/messenger": "^6.4|^7.0|^8.0",
-                "symfony/process": "^6.4|^7.0|^8.0",
-                "symfony/stopwatch": "^6.4|^7.0|^8.0",
-                "symfony/var-dumper": "^6.4|^7.0|^8.0"
+                "symfony/config": "^7.4|^8.0",
+                "symfony/dependency-injection": "^7.4|^8.0",
+                "symfony/event-dispatcher": "^7.4|^8.0",
+                "symfony/http-foundation": "^7.4|^8.0",
+                "symfony/http-kernel": "^7.4|^8.0",
+                "symfony/lock": "^7.4|^8.0",
+                "symfony/messenger": "^7.4|^8.0",
+                "symfony/process": "^7.4|^8.0",
+                "symfony/stopwatch": "^7.4|^8.0",
+                "symfony/var-dumper": "^7.4|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -4002,7 +3992,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v7.4.4"
+                "source": "https://github.com/symfony/console/tree/v8.0.8"
             },
             "funding": [
                 {
@@ -4022,7 +4012,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-13T11:36:38+00:00"
+            "time": "2026-03-30T15:14:47+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -4093,16 +4083,16 @@
         },
         {
             "name": "symfony/finder",
-            "version": "v8.0.5",
+            "version": "v8.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "8bd576e97c67d45941365bf824e18dc8538e6eb0"
+                "reference": "8da41214757b87d97f181e3d14a4179286151007"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/8bd576e97c67d45941365bf824e18dc8538e6eb0",
-                "reference": "8bd576e97c67d45941365bf824e18dc8538e6eb0",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/8da41214757b87d97f181e3d14a4179286151007",
+                "reference": "8da41214757b87d97f181e3d14a4179286151007",
                 "shasum": ""
             },
             "require": {
@@ -4137,7 +4127,7 @@
             "description": "Finds files and directories via an intuitive fluent interface",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/finder/tree/v8.0.5"
+                "source": "https://github.com/symfony/finder/tree/v8.0.8"
             },
             "funding": [
                 {
@@ -4157,7 +4147,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-26T15:08:38+00:00"
+            "time": "2026-03-30T15:14:47+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -4496,16 +4486,16 @@
         },
         {
             "name": "symfony/process",
-            "version": "v8.0.5",
+            "version": "v8.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "b5f3aa6762e33fd95efbaa2ec4f4bc9fdd16d674"
+                "reference": "cb8939aff03470d1a9d1d1b66d08c6fa71b3bbdc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/b5f3aa6762e33fd95efbaa2ec4f4bc9fdd16d674",
-                "reference": "b5f3aa6762e33fd95efbaa2ec4f4bc9fdd16d674",
+                "url": "https://api.github.com/repos/symfony/process/zipball/cb8939aff03470d1a9d1d1b66d08c6fa71b3bbdc",
+                "reference": "cb8939aff03470d1a9d1d1b66d08c6fa71b3bbdc",
                 "shasum": ""
             },
             "require": {
@@ -4537,7 +4527,7 @@
             "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v8.0.5"
+                "source": "https://github.com/symfony/process/tree/v8.0.8"
             },
             "funding": [
                 {
@@ -4557,7 +4547,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-26T15:08:38+00:00"
+            "time": "2026-03-30T15:14:47+00:00"
         },
         {
             "name": "symfony/service-contracts",
@@ -4648,16 +4638,16 @@
         },
         {
             "name": "symfony/string",
-            "version": "v8.0.4",
+            "version": "v8.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "758b372d6882506821ed666032e43020c4f57194"
+                "reference": "ae9488f874d7603f9d2dfbf120203882b645d963"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/758b372d6882506821ed666032e43020c4f57194",
-                "reference": "758b372d6882506821ed666032e43020c4f57194",
+                "url": "https://api.github.com/repos/symfony/string/zipball/ae9488f874d7603f9d2dfbf120203882b645d963",
+                "reference": "ae9488f874d7603f9d2dfbf120203882b645d963",
                 "shasum": ""
             },
             "require": {
@@ -4714,7 +4704,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v8.0.4"
+                "source": "https://github.com/symfony/string/tree/v8.0.8"
             },
             "funding": [
                 {
@@ -4734,27 +4724,27 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-12T12:37:40+00:00"
+            "time": "2026-03-30T15:14:47+00:00"
         },
         {
             "name": "ta-tikoma/phpunit-architecture-test",
-            "version": "0.8.6",
+            "version": "0.8.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ta-tikoma/phpunit-architecture-test.git",
-                "reference": "ad48430b92901fd7d003fdaf2d7b139f96c0906e"
+                "reference": "1248f3f506ca9641d4f68cebcd538fa489754db8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ta-tikoma/phpunit-architecture-test/zipball/ad48430b92901fd7d003fdaf2d7b139f96c0906e",
-                "reference": "ad48430b92901fd7d003fdaf2d7b139f96c0906e",
+                "url": "https://api.github.com/repos/ta-tikoma/phpunit-architecture-test/zipball/1248f3f506ca9641d4f68cebcd538fa489754db8",
+                "reference": "1248f3f506ca9641d4f68cebcd538fa489754db8",
                 "shasum": ""
             },
             "require": {
                 "nikic/php-parser": "^4.18.0 || ^5.0.0",
                 "php": "^8.1.0",
                 "phpdocumentor/reflection-docblock": "^5.3.0 || ^6.0.0",
-                "phpunit/phpunit": "^10.5.5 || ^11.0.0 || ^12.0.0",
+                "phpunit/phpunit": "^10.5.5 || ^11.0.0 || ^12.0.0 || ^13.0.0",
                 "symfony/finder": "^6.4.0 || ^7.0.0 || ^8.0.0"
             },
             "require-dev": {
@@ -4791,9 +4781,9 @@
             ],
             "support": {
                 "issues": "https://github.com/ta-tikoma/phpunit-architecture-test/issues",
-                "source": "https://github.com/ta-tikoma/phpunit-architecture-test/tree/0.8.6"
+                "source": "https://github.com/ta-tikoma/phpunit-architecture-test/tree/0.8.7"
             },
-            "time": "2026-01-30T07:16:00+00:00"
+            "time": "2026-02-17T17:25:14+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -4847,16 +4837,16 @@
         },
         {
             "name": "webmozart/assert",
-            "version": "2.1.2",
+            "version": "2.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webmozarts/assert.git",
-                "reference": "ce6a2f100c404b2d32a1dd1270f9b59ad4f57649"
+                "reference": "ff31ad6efc62e66e518fbab1cde3453d389bcdc8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozarts/assert/zipball/ce6a2f100c404b2d32a1dd1270f9b59ad4f57649",
-                "reference": "ce6a2f100c404b2d32a1dd1270f9b59ad4f57649",
+                "url": "https://api.github.com/repos/webmozarts/assert/zipball/ff31ad6efc62e66e518fbab1cde3453d389bcdc8",
+                "reference": "ff31ad6efc62e66e518fbab1cde3453d389bcdc8",
                 "shasum": ""
             },
             "require": {
@@ -4903,9 +4893,9 @@
             ],
             "support": {
                 "issues": "https://github.com/webmozarts/assert/issues",
-                "source": "https://github.com/webmozarts/assert/tree/2.1.2"
+                "source": "https://github.com/webmozarts/assert/tree/2.1.6"
             },
-            "time": "2026-01-13T14:02:24+00:00"
+            "time": "2026-02-27T10:28:38+00:00"
         }
     ],
     "aliases": [],

--- a/example/tests/Feature/AttachmentsTest.php
+++ b/example/tests/Feature/AttachmentsTest.php
@@ -3,12 +3,11 @@
 use function Qase\PestReporter\qase;
 
 it('attaches a file', function () {
-    // Create temp file for demo
     $tempFile = sys_get_temp_dir() . '/test-attachment.txt';
     file_put_contents($tempFile, 'Test content for attachment');
 
     qase()
-        ->caseId(10)
+        ->caseId(400)
         ->attach($tempFile)
         ->comment('File attached to this test');
 
@@ -19,7 +18,7 @@ it('attaches a file', function () {
 
 it('attaches content directly', function () {
     qase()
-        ->caseId(11)
+        ->caseId(401)
         ->attach((object)[
             'title' => 'response.json',
             'content' => json_encode(['status' => 'ok', 'message' => 'Success']),
@@ -38,7 +37,7 @@ it('attaches multiple files', function () {
     file_put_contents($tempFile2, 'Content 2');
 
     qase()
-        ->caseId(12)
+        ->caseId(402)
         ->attach([$tempFile1, $tempFile2])
         ->comment('Multiple files attached');
 
@@ -51,7 +50,7 @@ it('attaches multiple files', function () {
 
 it('attaches text content', function () {
     qase()
-        ->caseId(13)
+        ->caseId(403)
         ->attach((object)[
             'title' => 'debug.log',
             'content' => "Line 1: Starting test\nLine 2: Test in progress\nLine 3: Test completed",

--- a/example/tests/Feature/BasicTest.php
+++ b/example/tests/Feature/BasicTest.php
@@ -1,23 +1,30 @@
 <?php
 
+use function Qase\PestReporter\qase;
+
 it('passes successfully', function () {
+    qase()->caseId(1);
     expect(true)->toBeTrue();
 });
 
 it('fails intentionally', function () {
+    qase()->caseId(2);
     expect(false)->toBeTrue();
-})->skip('Demonstration of failed test');
+});
 
 it('is skipped', function () {
+    qase()->caseId(3);
     expect(true)->toBeTrue();
 })->skip('Demonstration of skipped test');
 
 it('performs basic math', function () {
+    qase()->caseId(4);
     $result = 2 + 2;
     expect($result)->toBe(4);
 });
 
 it('works with strings', function () {
+    qase()->caseId(5);
     $text = 'Hello, Qase!';
     expect($text)->toContain('Qase');
 });

--- a/example/tests/Feature/DataProviderTest.php
+++ b/example/tests/Feature/DataProviderTest.php
@@ -3,7 +3,7 @@
 use function Qase\PestReporter\qase;
 
 it('works with data providers', function (int $a, int $b, int $expected) {
-    qase()->caseId(20);
+    qase()->caseId(600);
 
     expect($a + $b)->toBe($expected);
 })->with([
@@ -14,7 +14,7 @@ it('works with data providers', function (int $a, int $b, int $expected) {
 
 it('validates email formats', function (string $email, bool $isValid) {
     qase()
-        ->caseId(21)
+        ->caseId(601)
         ->parameter('email', $email)
         ->parameter('expected', $isValid ? 'valid' : 'invalid');
 
@@ -28,7 +28,7 @@ it('validates email formats', function (string $email, bool $isValid) {
 ]);
 
 it('calculates factorial', function (int $n, int $expected) {
-    qase()->caseId(22);
+    qase()->caseId(602);
 
     $factorial = function (int $n) use (&$factorial): int {
         return $n <= 1 ? 1 : $n * $factorial($n - 1);
@@ -44,7 +44,7 @@ it('calculates factorial', function (int $n, int $expected) {
 
 it('checks string length', function (string $input, int $expectedLength) {
     qase()
-        ->caseId(23)
+        ->caseId(603)
         ->comment("Testing string: '{$input}'");
 
     expect(strlen($input))->toBe($expectedLength);

--- a/example/tests/Feature/FluentApiTest.php
+++ b/example/tests/Feature/FluentApiTest.php
@@ -4,7 +4,7 @@ use function Qase\PestReporter\qase;
 
 it('demonstrates fluent API with caseId', function () {
     qase()
-        ->caseId(1)
+        ->caseId(200)
         ->title('Fluent API Test')
         ->comment('This test uses fluent API');
 
@@ -12,13 +12,14 @@ it('demonstrates fluent API with caseId', function () {
 });
 
 it('demonstrates multiple case IDs', function () {
-    qase()->caseId(2, 3, 4);
+    qase()->caseId(201, 202, 203);
 
     expect(1 + 1)->toBe(2);
 });
 
 it('demonstrates suite hierarchy', function () {
     qase()
+        ->caseId(204)
         ->suite('Authentication', 'Login')
         ->field('priority', 'high')
         ->parameter('browser', 'chrome');
@@ -28,7 +29,7 @@ it('demonstrates suite hierarchy', function () {
 
 it('demonstrates chained fluent calls', function () {
     qase()
-        ->caseId(10)
+        ->caseId(205)
         ->title('Chained Fluent API Test')
         ->suite('API', 'Fluent')
         ->field('type', 'smoke')
@@ -39,6 +40,7 @@ it('demonstrates chained fluent calls', function () {
 });
 
 it('demonstrates comment only', function () {
+    qase()->caseId(206);
     qase()->comment('Simple comment for this test');
 
     expect(42)->toBe(42);

--- a/example/tests/Feature/QaseIdTest.php
+++ b/example/tests/Feature/QaseIdTest.php
@@ -35,3 +35,12 @@ it('uses title and field', function () {
 
     expect([1, 2, 3])->toHaveCount(3);
 });
+
+it('uses field with layer', function () {
+    qase()
+        ->caseId(106)
+        ->field('layer', 'e2e')
+        ->field('severity', 'major');
+
+    expect(true)->toBeTrue();
+});

--- a/example/tests/Feature/StepsTest.php
+++ b/example/tests/Feature/StepsTest.php
@@ -4,6 +4,7 @@ use Qase\PestReporter\Qase;
 use function Qase\PestReporter\qase;
 
 it('demonstrates simple step markers', function () {
+    qase()->caseId(300);
     qase()->step('Open login page');
     qase()->step('Enter username');
     qase()->step('Enter password');
@@ -13,18 +14,18 @@ it('demonstrates simple step markers', function () {
 });
 
 it('demonstrates steps with callbacks', function () {
+    qase()->caseId(301);
     qase()->step('Open login page', function () {
-        // Navigate to login page
         expect(true)->toBeTrue();
     });
 
     qase()->step('Submit form', function () {
-        // Submit the form
         expect(true)->toBeTrue();
     });
 });
 
 it('demonstrates nested steps', function () {
+    qase()->caseId(302);
     qase()->step('Login flow', function () {
         qase()->step('Enter credentials', function () {
             expect(true)->toBeTrue();
@@ -39,6 +40,7 @@ it('demonstrates nested steps', function () {
 });
 
 it('demonstrates steps with expected results', function () {
+    qase()->caseId(303);
     qase()->step('Click login button', expectedResult: 'Dashboard page loads');
     qase()->step('Open settings', function () {
         expect(true)->toBeTrue();
@@ -46,6 +48,7 @@ it('demonstrates steps with expected results', function () {
 });
 
 it('demonstrates facade steps', function () {
+    qase()->caseId(304);
     Qase::step('Open page', function () {
         expect(true)->toBeTrue();
     });
@@ -56,7 +59,7 @@ it('demonstrates facade steps', function () {
 
 it('demonstrates steps mixed with fluent API', function () {
     qase()
-        ->caseId(100)
+        ->caseId(305)
         ->title('Steps with fluent API')
         ->suite('Integration', 'Steps')
         ->step('Open page')

--- a/example/tests/Feature/SuitesTest.php
+++ b/example/tests/Feature/SuitesTest.php
@@ -5,18 +5,18 @@ use function Qase\PestReporter\qase;
 describe('Authentication', function () {
     describe('Login', function () {
         it('logs in with valid credentials', function () {
-            qase()->caseId(30)->comment('Testing valid login');
+            qase()->caseId(500)->comment('Testing valid login');
             expect(true)->toBeTrue();
         });
 
         it('rejects invalid credentials', function () {
-            qase()->caseId(31);
+            qase()->caseId(501);
             expect(false)->toBeFalse();
         });
 
         it('handles empty username', function () {
             qase()
-                ->caseId(32)
+                ->caseId(502)
                 ->field('type', 'smoke')
                 ->comment('Empty username should be rejected');
             expect('')->toBeEmpty();
@@ -25,13 +25,13 @@ describe('Authentication', function () {
 
     describe('Logout', function () {
         it('logs out successfully', function () {
-            qase()->caseId(33)->suite('Auth', 'Logout');
+            qase()->caseId(503)->suite('Auth', 'Logout');
             expect(true)->toBeTrue();
         });
 
         it('clears session on logout', function () {
             qase()
-                ->caseId(34)
+                ->caseId(504)
                 ->suite('Auth', 'Logout', 'Session')
                 ->comment('Session should be cleared');
             expect(null)->toBeNull();
@@ -42,21 +42,21 @@ describe('Authentication', function () {
 describe('User Management', function () {
     it('creates a new user', function () {
         qase()
-            ->caseId(40)
+            ->caseId(505)
             ->suite('Users', 'CRUD', 'Create');
         expect(true)->toBeTrue();
     });
 
     it('updates user profile', function () {
         qase()
-            ->caseId(41)
+            ->caseId(506)
             ->suite('Users', 'CRUD', 'Update');
         expect(true)->toBeTrue();
     });
 
     it('deletes a user', function () {
         qase()
-            ->caseId(42)
+            ->caseId(507)
             ->suite('Users', 'CRUD', 'Delete');
         expect(true)->toBeTrue();
     });

--- a/expected/pest-examples.yaml
+++ b/expected/pest-examples.yaml
@@ -1,0 +1,788 @@
+run:
+  stats:
+    passed: 50
+    failed: 1
+    skipped: 1
+    broken: 0
+    muted: 0
+    total: 52
+results:
+- title: calculates factorial
+  signature: 602::p::tests::feature::dataprovidertest::{"param0":"7"}::{"param1":"5040"}
+  status: passed
+  testops_ids:
+  - 602
+  params:
+    param0: '7'
+    param1: '5040'
+  relations:
+    suite:
+      data:
+      - title: P
+      - title: Tests
+      - title: Feature
+      - title: DataProviderTest
+- title: validates email formats
+  signature: 601::p::tests::feature::dataprovidertest::{"param0":"test@example.com"}::{"param1":"true"}::{"email":"test@example.com"}::{"expected":"valid"}
+  status: passed
+  testops_ids:
+  - 601
+  params:
+    param0: test@example.com
+    param1: 'true'
+    email: test@example.com
+    expected: valid
+  relations:
+    suite:
+      data:
+      - title: P
+      - title: Tests
+      - title: Feature
+      - title: DataProviderTest
+- title: performs basic math
+  signature: 4::p::tests::feature::basictest
+  status: passed
+  testops_ids:
+  - 4
+  relations:
+    suite:
+      data:
+      - title: P
+      - title: Tests
+      - title: Feature
+      - title: BasicTest
+- title: validates email formats
+  signature: 601::p::tests::feature::dataprovidertest::{"param0":"test@"}::{"param1":"false"}::{"email":"test@"}::{"expected":"invalid"}
+  status: passed
+  testops_ids:
+  - 601
+  params:
+    param0: test@
+    param1: 'false'
+    email: test@
+    expected: invalid
+  relations:
+    suite:
+      data:
+      - title: P
+      - title: Tests
+      - title: Feature
+      - title: DataProviderTest
+- title: demonstrates steps with callbacks
+  signature: 301::p::tests::feature::stepstest
+  status: passed
+  testops_ids:
+  - 301
+  relations:
+    suite:
+      data:
+      - title: P
+      - title: Tests
+      - title: Feature
+      - title: StepsTest
+  steps:
+  - data:
+      action: Open login page
+    execution:
+      status: passed
+  - data:
+      action: Submit form
+    execution:
+      status: passed
+- title: passes successfully
+  signature: 1::p::tests::feature::basictest
+  status: passed
+  testops_ids:
+  - 1
+  relations:
+    suite:
+      data:
+      - title: P
+      - title: Tests
+      - title: Feature
+      - title: BasicTest
+- title: checks string length
+  signature: 603::p::tests::feature::dataprovidertest::{"param0":"empty"}::{"param1":"0"}
+  status: passed
+  testops_ids:
+  - 603
+  params:
+    param0: empty
+    param1: '0'
+  relations:
+    suite:
+      data:
+      - title: P
+      - title: Tests
+      - title: Feature
+      - title: DataProviderTest
+- title: works with data providers
+  signature: 600::p::tests::feature::dataprovidertest::{"param0":"0"}::{"param1":"0"}::{"param2":"0"}
+  status: passed
+  testops_ids:
+  - 600
+  params:
+    param0: '0'
+    param1: '0'
+    param2: '0'
+  relations:
+    suite:
+      data:
+      - title: P
+      - title: Tests
+      - title: Feature
+      - title: DataProviderTest
+- title: Mixed Usage Test
+  signature: 51::p::tests::unit::exampletest
+  status: passed
+  testops_ids:
+  - 51
+  relations:
+    suite:
+      data:
+      - title: P
+      - title: Tests
+      - title: Unit
+      - title: ExampleTest
+- title: deletes a user
+  signature: 507::users::crud::delete
+  status: passed
+  testops_ids:
+  - 507
+  relations:
+    suite:
+      data:
+      - title: Users
+      - title: CRUD
+      - title: Delete
+- title: Fluent API Test
+  signature: 200::p::tests::feature::fluentapitest
+  status: passed
+  testops_ids:
+  - 200
+  relations:
+    suite:
+      data:
+      - title: P
+      - title: Tests
+      - title: Feature
+      - title: FluentApiTest
+- title: logs out successfully
+  signature: 503::auth::logout
+  status: passed
+  testops_ids:
+  - 503
+  relations:
+    suite:
+      data:
+      - title: Auth
+      - title: Logout
+- title: uses field with layer
+  signature: 106::p::tests::feature::qaseidtest
+  status: passed
+  testops_ids:
+  - 106
+  fields:
+    layer: e2e
+    severity: major
+  relations:
+    suite:
+      data:
+      - title: P
+      - title: Tests
+      - title: Feature
+      - title: QaseIdTest
+- title: tests array operations
+  signature: 53::unit::arrays
+  status: passed
+  testops_ids:
+  - 53
+  fields:
+    complexity: simple
+  relations:
+    suite:
+      data:
+      - title: Unit
+      - title: Arrays
+- title: Custom title via fluent API
+  signature: 105::p::tests::feature::qaseidtest
+  status: passed
+  testops_ids:
+  - 105
+  fields:
+    description: This is a test with custom field
+  relations:
+    suite:
+      data:
+      - title: P
+      - title: Tests
+      - title: Feature
+      - title: QaseIdTest
+- title: attaches multiple files
+  signature: 402::p::tests::feature::attachmentstest
+  status: passed
+  testops_ids:
+  - 402
+  relations:
+    suite:
+      data:
+      - title: P
+      - title: Tests
+      - title: Feature
+      - title: AttachmentsTest
+  attachments:
+  - file_name: attachment1.txt
+    mime_type: text/plain
+  - file_name: attachment2.txt
+    mime_type: text/plain
+- title: creates a new user
+  signature: 505::users::crud::create
+  status: passed
+  testops_ids:
+  - 505
+  relations:
+    suite:
+      data:
+      - title: Users
+      - title: CRUD
+      - title: Create
+- title: checks string length
+  signature: 603::p::tests::feature::dataprovidertest::{"param0":"a"}::{"param1":"1"}
+  status: passed
+  testops_ids:
+  - 603
+  params:
+    param0: a
+    param1: '1'
+  relations:
+    suite:
+      data:
+      - title: P
+      - title: Tests
+      - title: Feature
+      - title: DataProviderTest
+- title: demonstrates comment only
+  signature: 206::p::tests::feature::fluentapitest
+  status: passed
+  testops_ids:
+  - 206
+  relations:
+    suite:
+      data:
+      - title: P
+      - title: Tests
+      - title: Feature
+      - title: FluentApiTest
+- title: Steps with fluent API
+  signature: 305::integration::steps
+  status: passed
+  testops_ids:
+  - 305
+  relations:
+    suite:
+      data:
+      - title: Integration
+      - title: Steps
+  steps:
+  - data:
+      action: Open page
+    execution:
+      status: passed
+  - data:
+      action: Fill form
+    execution:
+      status: passed
+  - data:
+      action: Submit
+      expected_result: Form submitted
+    execution:
+      status: passed
+- title: demonstrates nested steps
+  signature: 302::p::tests::feature::stepstest
+  status: passed
+  testops_ids:
+  - 302
+  relations:
+    suite:
+      data:
+      - title: P
+      - title: Tests
+      - title: Feature
+      - title: StepsTest
+  steps:
+  - data:
+      action: Login flow
+    execution:
+      status: passed
+    steps:
+    - data:
+        action: Enter credentials
+      execution:
+        status: passed
+    - data:
+        action: Click submit
+      execution:
+        status: passed
+  - data:
+      action: Verify dashboard
+    execution:
+      status: passed
+    steps:
+    - data:
+        action: Check welcome message
+      execution:
+        status: passed
+    - data:
+        action: Check navigation menu
+      execution:
+        status: passed
+- title: demonstrates facade steps
+  signature: 304::p::tests::feature::stepstest
+  status: passed
+  testops_ids:
+  - 304
+  relations:
+    suite:
+      data:
+      - title: P
+      - title: Tests
+      - title: Feature
+      - title: StepsTest
+  steps:
+  - data:
+      action: Open page
+    execution:
+      status: passed
+  - data:
+      action: Verify content
+    execution:
+      status: passed
+  - data:
+      action: Check footer
+      expected_result: Footer is visible
+    execution:
+      status: passed
+- title: attaches a file
+  signature: 400::p::tests::feature::attachmentstest
+  status: passed
+  testops_ids:
+  - 400
+  relations:
+    suite:
+      data:
+      - title: P
+      - title: Tests
+      - title: Feature
+      - title: AttachmentsTest
+  attachments:
+  - file_name: test-attachment.txt
+    mime_type: text/plain
+- title: demonstrates multiple case IDs
+  signature: 201-202-203::p::tests::feature::fluentapitest
+  status: passed
+  testops_ids:
+  - 201
+  - 202
+  - 203
+  relations:
+    suite:
+      data:
+      - title: P
+      - title: Tests
+      - title: Feature
+      - title: FluentApiTest
+- title: validates email formats
+  signature: 601::p::tests::feature::dataprovidertest::{"param0":"invalid-email"}::{"param1":"false"}::{"email":"invalid-email"}::{"expected":"invalid"}
+  status: passed
+  testops_ids:
+  - 601
+  params:
+    param0: invalid-email
+    param1: 'false'
+    email: invalid-email
+    expected: invalid
+  relations:
+    suite:
+      data:
+      - title: P
+      - title: Tests
+      - title: Feature
+      - title: DataProviderTest
+- title: attaches content directly
+  signature: 401::p::tests::feature::attachmentstest
+  status: passed
+  testops_ids:
+  - 401
+  relations:
+    suite:
+      data:
+      - title: P
+      - title: Tests
+      - title: Feature
+      - title: AttachmentsTest
+  attachments:
+  - file_name: response.json
+    mime_type: application/json
+- title: is a simple unit test
+  signature: 52::unit::math
+  status: passed
+  testops_ids:
+  - 52
+  relations:
+    suite:
+      data:
+      - title: Unit
+      - title: Math
+- title: demonstrates steps with expected results
+  signature: 303::p::tests::feature::stepstest
+  status: passed
+  testops_ids:
+  - 303
+  relations:
+    suite:
+      data:
+      - title: P
+      - title: Tests
+      - title: Feature
+      - title: StepsTest
+  steps:
+  - data:
+      action: Click login button
+      expected_result: Dashboard page loads
+    execution:
+      status: passed
+  - data:
+      action: Open settings
+      expected_result: Settings page is displayed
+    execution:
+      status: passed
+- title: calculates factorial
+  signature: 602::p::tests::feature::dataprovidertest::{"param0":"1"}::{"param1":"1"}
+  status: passed
+  testops_ids:
+  - 602
+  params:
+    param0: '1'
+    param1: '1'
+  relations:
+    suite:
+      data:
+      - title: P
+      - title: Tests
+      - title: Feature
+      - title: DataProviderTest
+- title: calculates factorial
+  signature: 602::p::tests::feature::dataprovidertest::{"param0":"5"}::{"param1":"120"}
+  status: passed
+  testops_ids:
+  - 602
+  params:
+    param0: '5'
+    param1: '120'
+  relations:
+    suite:
+      data:
+      - title: P
+      - title: Tests
+      - title: Feature
+      - title: DataProviderTest
+- title: checks string length
+  signature: 603::p::tests::feature::dataprovidertest::{"hello":"5"}
+  status: passed
+  testops_ids:
+  - 603
+  params:
+    hello: '5'
+  relations:
+    suite:
+      data:
+      - title: P
+      - title: Tests
+      - title: Feature
+      - title: DataProviderTest
+- title: combines caseId with suite and field
+  signature: 104::attributes::priority
+  status: passed
+  testops_ids:
+  - 104
+  fields:
+    severity: critical
+  relations:
+    suite:
+      data:
+      - title: Attributes
+      - title: Priority
+- title: Chained Fluent API Test
+  signature: 205::api::fluent::{"env":"staging"}
+  status: passed
+  testops_ids:
+  - 205
+  fields:
+    type: smoke
+  params:
+    env: staging
+  relations:
+    suite:
+      data:
+      - title: API
+      - title: Fluent
+- title: is skipped
+  signature: p::tests::feature::basictest
+  status: skipped
+  relations:
+    suite:
+      data:
+      - title: P
+      - title: Tests
+      - title: Feature
+      - title: BasicTest
+- title: calculates factorial
+  signature: 602::p::tests::feature::dataprovidertest::{"param0":"0"}::{"param1":"1"}
+  status: passed
+  testops_ids:
+  - 602
+  params:
+    param0: '0'
+    param1: '1'
+  relations:
+    suite:
+      data:
+      - title: P
+      - title: Tests
+      - title: Feature
+      - title: DataProviderTest
+- title: validates email formats
+  signature: 601::p::tests::feature::dataprovidertest::{"param0":"user.name@domain.org"}::{"param1":"true"}::{"email":"user.name@domain.org"}::{"expected":"valid"}
+  status: passed
+  testops_ids:
+  - 601
+  params:
+    param0: user.name@domain.org
+    param1: 'true'
+    email: user.name@domain.org
+    expected: valid
+  relations:
+    suite:
+      data:
+      - title: P
+      - title: Tests
+      - title: Feature
+      - title: DataProviderTest
+- title: works with data providers
+  signature: 600::p::tests::feature::dataprovidertest::{"param0":"2"}::{"param1":"2"}::{"param2":"4"}
+  status: passed
+  testops_ids:
+  - 600
+  params:
+    param0: '2'
+    param1: '2'
+    param2: '4'
+  relations:
+    suite:
+      data:
+      - title: P
+      - title: Tests
+      - title: Feature
+      - title: DataProviderTest
+- title: works with strings
+  signature: 5::p::tests::feature::basictest
+  status: passed
+  testops_ids:
+  - 5
+  relations:
+    suite:
+      data:
+      - title: P
+      - title: Tests
+      - title: Feature
+      - title: BasicTest
+- title: updates user profile
+  signature: 506::users::crud::update
+  status: passed
+  testops_ids:
+  - 506
+  relations:
+    suite:
+      data:
+      - title: Users
+      - title: CRUD
+      - title: Update
+- title: demonstrates suite hierarchy
+  signature: 204::authentication::login::{"browser":"chrome"}
+  status: passed
+  testops_ids:
+  - 204
+  fields:
+    priority: high
+  params:
+    browser: chrome
+  relations:
+    suite:
+      data:
+      - title: Authentication
+      - title: Login
+- title: logs in with valid credentials
+  signature: 500::authentication::login
+  status: passed
+  testops_ids:
+  - 500
+  relations:
+    suite:
+      data:
+      - title: Authentication
+      - title: Login
+- title: rejects invalid credentials
+  signature: 501::authentication::login
+  status: passed
+  testops_ids:
+  - 501
+  relations:
+    suite:
+      data:
+      - title: Authentication
+      - title: Login
+- title: Test with single QaseId
+  signature: 100::p::tests::feature::qaseidtest
+  status: passed
+  testops_ids:
+  - 100
+  relations:
+    suite:
+      data:
+      - title: P
+      - title: Tests
+      - title: Feature
+      - title: QaseIdTest
+- title: Static Facade Test
+  signature: 50::p::tests::unit::exampletest
+  status: passed
+  testops_ids:
+  - 50
+  relations:
+    suite:
+      data:
+      - title: P
+      - title: Tests
+      - title: Unit
+      - title: ExampleTest
+- title: fails intentionally
+  signature: 2::p::tests::feature::basictest
+  status: failed
+  testops_ids:
+  - 2
+  relations:
+    suite:
+      data:
+      - title: P
+      - title: Tests
+      - title: Feature
+      - title: BasicTest
+- title: checks string length
+  signature: 603::p::tests::feature::dataprovidertest::{"param0":"test string"}::{"param1":"11"}
+  status: passed
+  testops_ids:
+  - 603
+  params:
+    param0: test string
+    param1: '11'
+  relations:
+    suite:
+      data:
+      - title: P
+      - title: Tests
+      - title: Feature
+      - title: DataProviderTest
+- title: handles empty username
+  signature: 502::authentication::login
+  status: passed
+  testops_ids:
+  - 502
+  fields:
+    type: smoke
+  relations:
+    suite:
+      data:
+      - title: Authentication
+      - title: Login
+- title: uses multiple QaseIds
+  signature: 101-102-103::attributes
+  status: passed
+  testops_ids:
+  - 101
+  - 102
+  - 103
+  relations:
+    suite:
+      data:
+      - title: Attributes
+- title: clears session on logout
+  signature: 504::auth::logout::session
+  status: passed
+  testops_ids:
+  - 504
+  relations:
+    suite:
+      data:
+      - title: Auth
+      - title: Logout
+      - title: Session
+- title: demonstrates simple step markers
+  signature: 300::p::tests::feature::stepstest
+  status: passed
+  testops_ids:
+  - 300
+  relations:
+    suite:
+      data:
+      - title: P
+      - title: Tests
+      - title: Feature
+      - title: StepsTest
+  steps:
+  - data:
+      action: Open login page
+    execution:
+      status: passed
+  - data:
+      action: Enter username
+    execution:
+      status: passed
+  - data:
+      action: Enter password
+    execution:
+      status: passed
+  - data:
+      action: Click login
+    execution:
+      status: passed
+- title: attaches text content
+  signature: 403::p::tests::feature::attachmentstest
+  status: passed
+  testops_ids:
+  - 403
+  relations:
+    suite:
+      data:
+      - title: P
+      - title: Tests
+      - title: Feature
+      - title: AttachmentsTest
+  attachments:
+  - file_name: debug.log
+    mime_type: text/plain
+- title: works with data providers
+  signature: 600::p::tests::feature::dataprovidertest::{"param0":"1"}::{"param1":"1"}::{"param2":"2"}
+  status: passed
+  testops_ids:
+  - 600
+  params:
+    param0: '1'
+    param1: '1'
+    param2: '2'
+  relations:
+    suite:
+      data:
+      - title: P
+      - title: Tests
+      - title: Feature
+      - title: DataProviderTest

--- a/scripts/clean_expected.py
+++ b/scripts/clean_expected.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""
+Clean expected YAML files by removing dynamic fields that change between runs.
+
+Removes:
+- execution blocks (keeps only top-level status)
+- Step IDs and timestamps (start_time, end_time, duration)
+- Attachment IDs and file_path (keeps file_name and mime_type)
+- Empty collections: fields: {}, attachments: [], params: {}, param_groups: [], steps: []
+- muted: false (default value)
+- message (contains dynamic timestamps and unstable whitespace)
+- stacktrace (contains absolute file paths)
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+import yaml
+
+
+def clean_execution(execution: dict) -> dict | None:
+    """Keep only top-level status from execution block."""
+    if not execution:
+        return None
+    cleaned = {}
+    if "status" in execution:
+        cleaned["status"] = execution["status"]
+    return cleaned if cleaned else None
+
+
+def clean_steps(steps: list) -> list:
+    """Clean step entries: remove IDs, timestamps, clean nested execution."""
+    cleaned = []
+    for step in steps:
+        clean_step = {}
+
+        if "data" in step and step["data"]:
+            data = {}
+            if "action" in step["data"]:
+                data["action"] = step["data"]["action"]
+            if "expected_result" in step["data"] and step["data"]["expected_result"]:
+                data["expected_result"] = step["data"]["expected_result"]
+            if data:
+                clean_step["data"] = data
+
+        if "execution" in step and step["execution"]:
+            exec_cleaned = clean_execution(step["execution"])
+            if exec_cleaned:
+                clean_step["execution"] = exec_cleaned
+
+        if "steps" in step and step["steps"]:
+            nested = clean_steps(step["steps"])
+            if nested:
+                clean_step["steps"] = nested
+
+        if clean_step:
+            cleaned.append(clean_step)
+
+    return cleaned
+
+
+def clean_attachments(attachments: list) -> list:
+    """Keep only file_name and mime_type from attachments."""
+    cleaned = []
+    for att in attachments:
+        clean_att = {}
+        if "file_name" in att and att["file_name"]:
+            clean_att["file_name"] = att["file_name"]
+        if "mime_type" in att and att["mime_type"]:
+            clean_att["mime_type"] = att["mime_type"]
+        if clean_att:
+            cleaned.append(clean_att)
+    return cleaned
+
+
+def clean_relations(relations: dict) -> dict | None:
+    """Clean relations: remove public_id from suite data."""
+    if not relations:
+        return None
+    cleaned = {}
+    if "suite" in relations and relations["suite"]:
+        suite = relations["suite"]
+        if "data" in suite and suite["data"]:
+            clean_data = []
+            for item in suite["data"]:
+                clean_item = {}
+                if "title" in item:
+                    clean_item["title"] = item["title"]
+                if clean_item:
+                    clean_data.append(clean_item)
+            if clean_data:
+                cleaned["suite"] = {"data": clean_data}
+    return cleaned if cleaned else None
+
+
+def clean_result(result: dict) -> dict:
+    """Clean a single test result."""
+    cleaned = {}
+
+    # Keep core fields
+    for key in ["title", "signature", "status"]:
+        if key in result and result[key]:
+            cleaned[key] = result[key]
+
+    # Keep testops_ids (skip singular testops_id)
+    if "testops_ids" in result and result["testops_ids"]:
+        cleaned["testops_ids"] = result["testops_ids"]
+
+    # Keep non-empty fields
+    if "fields" in result and result["fields"]:
+        cleaned["fields"] = result["fields"]
+
+    # Keep non-empty params
+    if "params" in result and result["params"]:
+        cleaned["params"] = result["params"]
+
+    # Keep non-empty param_groups
+    if "param_groups" in result and result["param_groups"]:
+        cleaned["param_groups"] = result["param_groups"]
+
+    # Clean relations (remove public_id)
+    if "relations" in result and result["relations"]:
+        rel = clean_relations(result["relations"])
+        if rel:
+            cleaned["relations"] = rel
+
+    # Clean steps
+    if "steps" in result and result["steps"]:
+        steps = clean_steps(result["steps"])
+        if steps:
+            cleaned["steps"] = steps
+
+    # Clean attachments
+    if "attachments" in result and result["attachments"]:
+        atts = clean_attachments(result["attachments"])
+        if atts:
+            cleaned["attachments"] = atts
+
+    # Skip execution (keep only top-level status which is already in "status" field)
+    # Skip muted: false (default value)
+    # Skip message (dynamic timestamps, unstable whitespace)
+    # Skip stacktrace (absolute file paths)
+    # Skip testops_id (singular, redundant with testops_ids)
+
+    # Keep muted only when true
+    if "muted" in result and result["muted"]:
+        cleaned["muted"] = result["muted"]
+
+    return cleaned
+
+
+def clean_expected(data: dict) -> dict:
+    """Clean the entire expected data structure."""
+    cleaned = {}
+
+    # Keep run stats
+    if "run" in data:
+        cleaned["run"] = data["run"]
+
+    # Clean results
+    if "results" in data:
+        cleaned["results"] = [clean_result(r) for r in data["results"]]
+
+    return cleaned
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Clean expected YAML files")
+    parser.add_argument(
+        "--input",
+        required=True,
+        help="Path to the expected YAML file to clean",
+    )
+    parser.add_argument(
+        "--output",
+        help="Path to write cleaned YAML (defaults to overwriting input)",
+    )
+    args = parser.parse_args()
+
+    input_path = Path(args.input)
+    output_path = Path(args.output) if args.output else input_path
+
+    if not input_path.exists():
+        print(f"Error: {input_path} does not exist", file=sys.stderr)
+        sys.exit(1)
+
+    with open(input_path) as f:
+        data = yaml.safe_load(f)
+
+    cleaned = clean_expected(data)
+
+    with open(output_path, "w") as f:
+        yaml.dump(cleaned, f, default_flow_style=False, allow_unicode=True, sort_keys=False)
+
+    print(f"Cleaned expected file written to {output_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/QaseReporter.php
+++ b/src/QaseReporter.php
@@ -200,7 +200,21 @@ class QaseReporter implements QaseReporterInterface
         $key = $this->getTestKey($test);
         $this->testResults[$key]->execution->finish();
 
-        $this->reporter->addResult($this->testResults[$key]);
+        // Regenerate signature to include testOpsIds and suites set via fluent API
+        $result = $this->testResults[$key];
+        $suites = [];
+        if ($result->relations->suite && !empty($result->relations->suite->data)) {
+            foreach ($result->relations->suite->data as $suiteData) {
+                $suites[] = $suiteData->title;
+            }
+        }
+        $result->signature = Signature::generateSignature(
+            $result->testOpsIds,
+            $suites,
+            $result->params ?: null,
+        );
+
+        $this->reporter->addResult($result);
     }
 
     private function getTestKey(TestMethod $test): string


### PR DESCRIPTION
## Summary

- **Fix signature generation**: `completeTest()` now regenerates signatures using final `testOpsIds`, `suites`, and `params` set via fluent API. Previously all tests in the same file got identical signatures because signature was computed in `startTest()` before test body executed.
- **Bump php-commons to ^2.1.17**: fixes params serialization format (object → string) and attachment.id nulls.
- **Add integration test infrastructure**: example tests with unique QaseIds, `scripts/clean_expected.py` for stripping dynamic fields, `expected/pest-examples.yaml` baseline (52 test results), and `integration-test` CI job that validates reporter output against JSON Schema and expected data using `reporters-validator`.

## Test plan

- [x] All 58 unit tests pass locally
- [x] `reporters-validator validate` outputs "All validations passed" locally
- [x] CI `integration-test` job passes on GitHub Actions
- [x] Existing `tests` matrix (PHP 8.2-8.4, Pest 2/3) still passes