### PR TITLE
feat: add Tags support via attributes and fluent API

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
   "require": {
     "php": "^8.2",
     "phpunit/phpunit": "^10 || ^11 || ^12",
-    "qase/php-commons": "^2.1.17"
+    "qase/php-commons": "^2.1.18"
   },
   "require-dev": {
     "pestphp/pest": "^2.0 || ^3.0"
@@ -40,7 +40,7 @@
       "Tests\\": "tests/"
     }
   },
-  "version": "1.0.2",
+  "version": "1.0.3",
   "scripts": {
     "test": "pest"
   },

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "33c5cb75fd234fb9594595145299b157",
+    "content-hash": "20e383681e5a1ea7276bf7ff61c48f6f",
     "packages": [
         {
             "name": "brick/math",
-            "version": "0.14.6",
+            "version": "0.14.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/brick/math.git",
-                "reference": "32498d5e1897e7642c0b961ace2df6d7dc9a3bc3"
+                "reference": "63422359a44b7f06cae63c3b429b59e8efcc0629"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/brick/math/zipball/32498d5e1897e7642c0b961ace2df6d7dc9a3bc3",
-                "reference": "32498d5e1897e7642c0b961ace2df6d7dc9a3bc3",
+                "url": "https://api.github.com/repos/brick/math/zipball/63422359a44b7f06cae63c3b429b59e8efcc0629",
+                "reference": "63422359a44b7f06cae63c3b429b59e8efcc0629",
                 "shasum": ""
             },
             "require": {
@@ -56,7 +56,7 @@
             ],
             "support": {
                 "issues": "https://github.com/brick/math/issues",
-                "source": "https://github.com/brick/math/tree/0.14.6"
+                "source": "https://github.com/brick/math/tree/0.14.8"
             },
             "funding": [
                 {
@@ -64,7 +64,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-02-05T07:59:58+00:00"
+            "time": "2026-02-10T14:33:43+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",
@@ -277,16 +277,16 @@
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "2.8.0",
+            "version": "2.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "21dc724a0583619cd1652f673303492272778051"
+                "reference": "7d0ed42f28e42d61352a7a79de682e5e67fec884"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/21dc724a0583619cd1652f673303492272778051",
-                "reference": "21dc724a0583619cd1652f673303492272778051",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/7d0ed42f28e42d61352a7a79de682e5e67fec884",
+                "reference": "7d0ed42f28e42d61352a7a79de682e5e67fec884",
                 "shasum": ""
             },
             "require": {
@@ -302,6 +302,7 @@
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
                 "http-interop/http-factory-tests": "0.9.0",
+                "jshttp/mime-db": "1.54.0.1",
                 "phpunit/phpunit": "^8.5.44 || ^9.6.25"
             },
             "suggest": {
@@ -373,7 +374,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/2.8.0"
+                "source": "https://github.com/guzzle/psr7/tree/2.9.0"
             },
             "funding": [
                 {
@@ -389,7 +390,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-23T21:21:41+00:00"
+            "time": "2026-03-10T16:41:02+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -1245,22 +1246,22 @@
         },
         {
             "name": "qase/php-commons",
-            "version": "2.1.17",
+            "version": "2.1.18",
             "source": {
                 "type": "git",
                 "url": "https://github.com/qase-tms/qase-php-commons.git",
-                "reference": "b9e8b70419e0ba2a5645879b4c5af23bad0b9e54"
+                "reference": "ca0459b6b97a7810a7aa1db15297f864827556d0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/qase-tms/qase-php-commons/zipball/b9e8b70419e0ba2a5645879b4c5af23bad0b9e54",
-                "reference": "b9e8b70419e0ba2a5645879b4c5af23bad0b9e54",
+                "url": "https://api.github.com/repos/qase-tms/qase-php-commons/zipball/ca0459b6b97a7810a7aa1db15297f864827556d0",
+                "reference": "ca0459b6b97a7810a7aa1db15297f864827556d0",
                 "shasum": ""
             },
             "require": {
                 "php": "^8.0",
                 "qase/qase-api-client": "^1.1.5",
-                "qase/qase-api-v2-client": "^1.1.2",
+                "qase/qase-api-v2-client": "^1.1.5",
                 "ramsey/uuid": "^4.7"
             },
             "require-dev": {
@@ -1294,22 +1295,22 @@
             ],
             "support": {
                 "issues": "https://github.com/qase-tms/qase-php-commons/issues",
-                "source": "https://github.com/qase-tms/qase-php-commons/tree/v2.1.17"
+                "source": "https://github.com/qase-tms/qase-php-commons/tree/v2.1.18"
             },
-            "time": "2026-04-06T12:01:38+00:00"
+            "time": "2026-04-09T08:02:34+00:00"
         },
         {
             "name": "qase/qase-api-client",
-            "version": "1.1.5",
+            "version": "1.1.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/qase-tms/qase-api-client.git",
-                "reference": "2a95fe3c8a09a3d733338cde79c3f97ce74ea6d2"
+                "reference": "edde038fcc858cd342eb900c076524798f635772"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/qase-tms/qase-api-client/zipball/2a95fe3c8a09a3d733338cde79c3f97ce74ea6d2",
-                "reference": "2a95fe3c8a09a3d733338cde79c3f97ce74ea6d2",
+                "url": "https://api.github.com/repos/qase-tms/qase-api-client/zipball/edde038fcc858cd342eb900c076524798f635772",
+                "reference": "edde038fcc858cd342eb900c076524798f635772",
                 "shasum": ""
             },
             "require": {
@@ -1350,22 +1351,22 @@
             ],
             "support": {
                 "issues": "https://github.com/qase-tms/qase-api-client/issues",
-                "source": "https://github.com/qase-tms/qase-api-client/tree/v1.1.5"
+                "source": "https://github.com/qase-tms/qase-api-client/tree/v1.1.10"
             },
-            "time": "2025-09-23T12:19:27+00:00"
+            "time": "2026-03-26T13:32:24+00:00"
         },
         {
             "name": "qase/qase-api-v2-client",
-            "version": "1.1.2",
+            "version": "1.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/qase-tms/qase-api-v2-client.git",
-                "reference": "1d70ae5efc88fdb24af60bd24e3f0352237ee86c"
+                "reference": "9cc363fc035bd66b8bdae5cf894525136d660000"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/qase-tms/qase-api-v2-client/zipball/1d70ae5efc88fdb24af60bd24e3f0352237ee86c",
-                "reference": "1d70ae5efc88fdb24af60bd24e3f0352237ee86c",
+                "url": "https://api.github.com/repos/qase-tms/qase-api-v2-client/zipball/9cc363fc035bd66b8bdae5cf894525136d660000",
+                "reference": "9cc363fc035bd66b8bdae5cf894525136d660000",
                 "shasum": ""
             },
             "require": {
@@ -1406,9 +1407,9 @@
             ],
             "support": {
                 "issues": "https://github.com/qase-tms/qase-api-v2-client/issues",
-                "source": "https://github.com/qase-tms/qase-api-v2-client/tree/v1.1.2"
+                "source": "https://github.com/qase-tms/qase-api-v2-client/tree/v1.1.5"
             },
-            "time": "2025-08-13T07:36:21+00:00"
+            "time": "2026-04-07T12:51:13+00:00"
         },
         {
             "name": "ralouphie/getallheaders",

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,527 @@
+# Qase Pest Reporter - Usage Guide
+
+This guide covers all available annotations, fluent API methods, and static facade for using the Qase Pest Reporter.
+
+## Table of Contents
+
+- [Annotations](#annotations)
+  - [QaseId](#qaseid)
+  - [QaseIds](#qaseids)
+  - [Title](#title)
+  - [Suite](#suite)
+  - [Field](#field)
+  - [Tags](#tags)
+  - [Parameter](#parameter)
+- [Fluent API](#fluent-api)
+  - [qase()->caseId()](#qase-caseid)
+  - [qase()->title()](#qase-title)
+  - [qase()->suite()](#qase-suite)
+  - [qase()->field()](#qase-field)
+  - [qase()->tag()](#qase-tag)
+  - [qase()->parameter()](#qase-parameter)
+  - [qase()->comment()](#qase-comment)
+  - [qase()->attach()](#qase-attach)
+  - [qase()->step()](#qase-step)
+- [Static Facade](#static-facade)
+- [Examples](#examples)
+- [Configuration](#configuration)
+- [Running Tests](#running-tests)
+
+## Annotations
+
+Annotations use PHP 8 attributes and are applied directly to test methods or classes.
+
+### QaseId
+
+Links a test to a specific Qase test case by ID.
+
+**Target:** Method only
+**Repeatable:** No
+
+```php
+#[QaseId(123)]
+it('logs in successfully', function () {
+    expect(true)->toBeTrue();
+});
+```
+
+### QaseIds
+
+Links a test to multiple Qase test cases by IDs.
+
+**Target:** Method only
+**Repeatable:** No
+
+```php
+#[QaseIds([1, 2, 3])]
+it('covers multiple scenarios', function () {
+    expect(true)->toBeTrue();
+});
+```
+
+**Note:** All IDs must be integers. Non-integer values will cause an exception.
+
+### Title
+
+Sets a custom title for the test case in Qase.
+
+**Target:** Method only
+**Repeatable:** No
+
+```php
+#[Title('User Login with Valid Credentials')]
+it('logs in successfully', function () {
+    expect(true)->toBeTrue();
+});
+```
+
+### Suite
+
+Assigns the test to one or more test suites in Qase.
+
+**Target:** Method and Class
+**Repeatable:** Yes
+
+```php
+// Single suite
+#[Suite('Authentication')]
+it('logs in successfully', function () {
+    expect(true)->toBeTrue();
+});
+
+// Multiple suites (hierarchical)
+#[
+    Suite('Authentication'),
+    Suite('Login')
+]
+it('logs in successfully', function () {
+    expect(true)->toBeTrue();
+});
+```
+
+### Field
+
+Adds custom fields to the test case in Qase.
+
+**Target:** Method and Class
+**Repeatable:** Yes
+
+```php
+#[
+    Field('description', 'Tests user login functionality'),
+    Field('severity', 'high'),
+    Field('priority', 'P1')
+]
+it('logs in successfully', function () {
+    expect(true)->toBeTrue();
+});
+```
+
+### Tags
+
+Adds tags to the test case in Qase. Tags from class-level and method-level attributes are merged (accumulated).
+
+**Target:** Method and Class
+**Repeatable:** Yes
+
+```php
+// Single tag set
+#[Tags('smoke', 'regression')]
+it('logs in successfully', function () {
+    expect(true)->toBeTrue();
+});
+
+// Multiple tag attributes (all tags are merged)
+#[
+    Tags('smoke'),
+    Tags('regression', 'critical')
+]
+it('logs in successfully', function () {
+    expect(true)->toBeTrue();
+});
+```
+
+### Parameter
+
+Adds parameters to the test case in Qase.
+
+**Target:** Method only
+**Repeatable:** Yes
+
+```php
+#[
+    Parameter('browser', 'chrome'),
+    Parameter('environment', 'staging')
+]
+it('logs in successfully', function () {
+    expect(true)->toBeTrue();
+});
+```
+
+## Fluent API
+
+The fluent API is the recommended way to add metadata to Pest tests. Import the `qase()` function and chain methods:
+
+```php
+use function Qase\PestReporter\qase;
+```
+
+### qase()->caseId()
+
+Links the test to one or more Qase test case IDs.
+
+```php
+it('logs in successfully', function () {
+    qase()->caseId(123);
+
+    expect(true)->toBeTrue();
+});
+
+// Multiple IDs
+it('covers multiple cases', function () {
+    qase()->caseId(1, 2, 3);
+
+    expect(true)->toBeTrue();
+});
+```
+
+### qase()->title()
+
+Sets a custom title for the test case.
+
+```php
+it('test', function () {
+    qase()->title('User Login with Valid Credentials');
+
+    expect(true)->toBeTrue();
+});
+```
+
+### qase()->suite()
+
+Sets the suite hierarchy for the test. Replaces any suites derived from `describe()` blocks or class namespace.
+
+```php
+it('test', function () {
+    qase()->suite('Authentication', 'Login');
+
+    expect(true)->toBeTrue();
+});
+```
+
+### qase()->field()
+
+Sets a custom field value for the test case.
+
+```php
+it('test', function () {
+    qase()->field('severity', 'critical');
+    qase()->field('priority', 'P1');
+
+    expect(true)->toBeTrue();
+});
+```
+
+### qase()->tag()
+
+Adds tags to the current test case. Multiple calls accumulate tags.
+
+```php
+it('test', function () {
+    qase()->tag('smoke', 'regression');
+
+    expect(true)->toBeTrue();
+});
+
+// Tags accumulate across multiple calls
+it('test', function () {
+    qase()->tag('smoke');
+    qase()->tag('regression');
+
+    expect(true)->toBeTrue();
+});
+```
+
+### qase()->parameter()
+
+Sets a parameter for the test case.
+
+```php
+it('test', function () {
+    qase()->parameter('browser', 'chrome');
+    qase()->parameter('environment', 'staging');
+
+    expect(true)->toBeTrue();
+});
+```
+
+### qase()->comment()
+
+Adds a comment to the test case.
+
+```php
+it('test', function () {
+    qase()->comment('Starting login test');
+
+    // Test implementation
+
+    qase()->comment('Login test completed');
+
+    expect(true)->toBeTrue();
+});
+```
+
+### qase()->attach()
+
+Adds attachments to the test case. Supports file paths, arrays of file paths, and content objects.
+
+```php
+// Single file
+it('test', function () {
+    qase()->attach('/path/to/screenshot.png');
+
+    expect(true)->toBeTrue();
+});
+
+// Multiple files
+it('test', function () {
+    qase()->attach(['/path/to/file1.png', '/path/to/file2.log']);
+
+    expect(true)->toBeTrue();
+});
+
+// Content attachment
+it('test', function () {
+    qase()->attach((object) [
+        'title' => 'response.json',
+        'content' => json_encode($response),
+        'mime' => 'application/json'
+    ]);
+
+    expect(true)->toBeTrue();
+});
+```
+
+### qase()->step()
+
+Adds test steps to structure test execution in Qase TMS.
+
+```php
+// Simple step markers
+it('test', function () {
+    qase()->step('Open login page');
+    qase()->step('Enter credentials');
+    qase()->step('Click submit');
+
+    expect(true)->toBeTrue();
+});
+
+// Steps with callbacks (auto-timed, status tracked)
+it('test', function () {
+    qase()->step('Fill login form', function () {
+        expect(true)->toBeTrue();
+    });
+
+    expect(true)->toBeTrue();
+});
+
+// Nested steps
+it('test', function () {
+    qase()->step('Login flow', function () {
+        qase()->step('Enter credentials', function () {
+            // nested step
+        });
+        qase()->step('Click submit');
+    });
+
+    expect(true)->toBeTrue();
+});
+
+// Steps with expected result
+it('test', function () {
+    qase()->step('Click login', expectedResult: 'Dashboard page loads');
+
+    expect(true)->toBeTrue();
+});
+```
+
+## Static Facade
+
+The static facade provides the same functionality as the fluent API but using static method calls. Import the `Qase` class:
+
+```php
+use Qase\PestReporter\Qase;
+```
+
+Available methods:
+
+| Static Method | Equivalent Fluent Method |
+|---|---|
+| `Qase::caseId(int ...$ids)` | `qase()->caseId(...)` |
+| `Qase::title(string $title)` | `qase()->title(...)` |
+| `Qase::suite(string ...$suites)` | `qase()->suite(...)` |
+| `Qase::field(string $name, string $value)` | `qase()->field(...)` |
+| `Qase::tag(string ...$tags)` | `qase()->tag(...)` |
+| `Qase::parameter(string $name, string $value)` | `qase()->parameter(...)` |
+| `Qase::comment(string $message)` | `qase()->comment(...)` |
+| `Qase::attach(mixed $input)` | `qase()->attach(...)` |
+| `Qase::step(string $action, ?callable $callback, ?string $expectedResult)` | `qase()->step(...)` |
+
+Example:
+
+```php
+use Qase\PestReporter\Qase;
+
+it('logs in successfully', function () {
+    Qase::caseId(123);
+    Qase::title('Login Test');
+    Qase::tag('smoke', 'regression');
+    Qase::comment('Testing login functionality');
+
+    expect(true)->toBeTrue();
+});
+```
+
+## Examples
+
+### Complete Fluent API Example
+
+```php
+use function Qase\PestReporter\qase;
+
+it('logs in successfully', function () {
+    qase()
+        ->caseId(123)
+        ->title('Login Test')
+        ->suite('Auth', 'Login')
+        ->field('priority', 'high')
+        ->tag('smoke', 'regression')
+        ->parameter('browser', 'chrome')
+        ->step('Open login page')
+        ->step('Submit credentials', function () {
+            expect(true)->toBeTrue();
+        })
+        ->comment('Testing login functionality')
+        ->attach('/path/to/screenshot.png');
+});
+```
+
+### Combining Annotations with Fluent API
+
+```php
+use function Qase\PestReporter\qase;
+use Qase\PestReporter\Attributes\QaseId;
+use Qase\PestReporter\Attributes\Tags;
+use Qase\PestReporter\Attributes\Suite;
+
+#[
+    QaseId(123),
+    Suite('Authentication'),
+    Tags('smoke', 'regression')
+]
+it('logs in successfully', function () {
+    qase()
+        ->comment('Testing login')
+        ->step('Submit form', function () {
+            expect(true)->toBeTrue();
+        });
+});
+```
+
+### Data Providers
+
+The reporter automatically extracts parameters from Pest's data providers:
+
+```php
+use function Qase\PestReporter\qase;
+
+it('adds numbers', function (int $a, int $b, int $expected) {
+    qase()->caseId(100);
+    expect($a + $b)->toBe($expected);
+})->with([
+    'one plus one' => [1, 1, 2],
+    'two plus two' => [2, 2, 4],
+]);
+```
+
+### Suite Hierarchy with Describe Blocks
+
+```php
+use function Qase\PestReporter\qase;
+
+describe('Authentication', function () {
+    describe('Login', function () {
+        it('logs in with valid credentials', function () {
+            qase()
+                ->caseId(1)
+                ->tag('smoke')
+                ->comment('Testing login');
+
+            expect(true)->toBeTrue();
+        });
+    });
+});
+```
+
+## Configuration
+
+### 1. Add PHPUnit Extension
+
+Add the Qase extension to your `phpunit.xml`:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit>
+    <extensions>
+        <bootstrap class="Qase\PestReporter\QaseExtension"/>
+    </extensions>
+</phpunit>
+```
+
+### 2. Create Configuration File
+
+Create `qase.config.json` in your project root:
+
+```json
+{
+  "mode": "testops",
+  "fallback": "report",
+  "testops": {
+    "api": {
+      "token": "YOUR_QASE_API_TOKEN",
+      "host": "qase.io"
+    },
+    "project": "YOUR_PROJECT_CODE",
+    "run": {
+      "title": "Pest Test Run",
+      "complete": true
+    }
+  },
+  "report": {
+    "driver": "local",
+    "connection": {
+      "path": "./build/qase-report"
+    }
+  }
+}
+```
+
+### 3. Environment Variables
+
+Alternatively, use environment variables:
+
+```bash
+QASE_MODE=testops
+QASE_TESTOPS_API_TOKEN=your_token
+QASE_TESTOPS_PROJECT=PROJECT_CODE
+```
+
+## Running Tests
+
+```bash
+# Run with local report
+./vendor/bin/pest
+
+# Run with Qase TMS integration
+QASE_MODE=testops ./vendor/bin/pest
+```

--- a/example/tests/Feature/QaseIdTest.php
+++ b/example/tests/Feature/QaseIdTest.php
@@ -44,3 +44,11 @@ it('uses field with layer', function () {
 
     expect(true)->toBeTrue();
 });
+
+it('uses tags', function () {
+    qase()
+        ->caseId(107)
+        ->tag('smoke', 'regression');
+
+    expect(true)->toBeTrue();
+});

--- a/expected/pest-examples.yaml
+++ b/expected/pest-examples.yaml
@@ -1,11 +1,11 @@
 run:
   stats:
-    passed: 50
+    passed: 51
     failed: 1
     skipped: 1
     broken: 0
     muted: 0
-    total: 52
+    total: 53
 results:
 - title: calculates factorial
   signature: 602::p::tests::feature::dataprovidertest::{"param0":"7"}::{"param1":"5040"}
@@ -786,3 +786,16 @@ results:
       - title: Tests
       - title: Feature
       - title: DataProviderTest
+- title: uses tags
+  signature: 107::p::tests::feature::qaseidtest
+  status: passed
+  testops_ids:
+  - 107
+  tags: smoke,regression
+  relations:
+    suite:
+      data:
+      - title: P
+      - title: Tests
+      - title: Feature
+      - title: QaseIdTest

--- a/src/Attributes/AttributeParser.php
+++ b/src/Attributes/AttributeParser.php
@@ -83,6 +83,10 @@ class AttributeParser implements AttributeParserInterface
             if ($annotation instanceof ParameterAttributeInterface) {
                 $metadata->parameters[$annotation->getName()] = $annotation->getValue();
             }
+
+            if ($annotation instanceof TagsAttributeInterface) {
+                $metadata->tags = array_merge($metadata->tags, $annotation->getTags());
+            }
         }
 
         return $metadata;

--- a/src/Attributes/Tags.php
+++ b/src/Attributes/Tags.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Qase\PestReporter\Attributes;
+
+use Attribute;
+
+/**
+ * Add tags to a test case in Qase
+ * Example:
+ * #[Tags("smoke", "regression")]
+ */
+#[Attribute(Attribute::TARGET_METHOD | Attribute::TARGET_CLASS | Attribute::IS_REPEATABLE)]
+final class Tags implements TagsAttributeInterface
+{
+    /** @var string[] */
+    private array $tags;
+
+    public function __construct(string ...$values)
+    {
+        $this->tags = $values;
+    }
+
+    public function getTags(): array
+    {
+        return $this->tags;
+    }
+}

--- a/src/Attributes/TagsAttributeInterface.php
+++ b/src/Attributes/TagsAttributeInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Qase\PestReporter\Attributes;
+
+interface TagsAttributeInterface extends AttributeInterface
+{
+    /**
+     * @return string[]
+     */
+    public function getTags(): array;
+}

--- a/src/Models/Metadata.php
+++ b/src/Models/Metadata.php
@@ -9,4 +9,5 @@ class Metadata
     public array $suites = [];
     public array $parameters = [];
     public array $fields = [];
+    public array $tags = [];
 }

--- a/src/NullQaseReporter.php
+++ b/src/NullQaseReporter.php
@@ -30,6 +30,11 @@ class NullQaseReporter
         return $this;
     }
 
+    public function tag(string ...$tags): self
+    {
+        return $this;
+    }
+
     public function parameter(string $name, mixed $value): self
     {
         return $this;

--- a/src/Qase.php
+++ b/src/Qase.php
@@ -120,6 +120,25 @@ class Qase
     }
 
     /**
+     * Add tags to the current test
+     *
+     * @param string ...$tags Tag names
+     * @return void
+     *
+     * Example:
+     * Qase::tag('smoke', 'regression');
+     */
+    public static function tag(string ...$tags): void
+    {
+        $qr = QaseReporter::getInstanceWithoutInit();
+        if (!$qr) {
+            return;
+        }
+
+        $qr->tag(...$tags);
+    }
+
+    /**
      * Set a parameter for the current test
      *
      * @param string $name Parameter name

--- a/src/QaseReporter.php
+++ b/src/QaseReporter.php
@@ -90,6 +90,7 @@ class QaseReporter implements QaseReporterInterface
         }
 
         $testResult->fields = $metadata->fields;
+        $testResult->tags = $metadata->tags;
         $testResult->params = $mergedParams;
         $testResult->signature = $this->createSignature($test, $metadata->qaseIds, $metadata->suites, $mergedParams);
         $testResult->execution->setThread($this->getThread());
@@ -385,6 +386,26 @@ class QaseReporter implements QaseReporterInterface
         }
 
         $this->testResults[$this->currentKey]->fields[$name] = $value;
+
+        return $this;
+    }
+
+    /**
+     * Add tags to the current test
+     *
+     * @param string ...$tags Tag names
+     * @return $this
+     */
+    public function tag(string ...$tags): self
+    {
+        if (!$this->currentKey || !isset($this->testResults[$this->currentKey])) {
+            return $this;
+        }
+
+        $this->testResults[$this->currentKey]->tags = array_merge(
+            $this->testResults[$this->currentKey]->tags,
+            $tags
+        );
 
         return $this;
     }

--- a/tests/Unit/ClassTagsFixture.php
+++ b/tests/Unit/ClassTagsFixture.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use Qase\PestReporter\Attributes\Tags;
+
+#[Tags('smoke')]
+class ClassTagsFixture
+{
+    #[Tags('regression')]
+    public function testWithMethodTags(): void {}
+}

--- a/tests/Unit/MetadataTest.php
+++ b/tests/Unit/MetadataTest.php
@@ -71,4 +71,17 @@ describe('Metadata', function () {
         expect($metadata->fields)->toBe(['priority' => 'high']);
     });
 
+    it('initializes with empty tags array', function () {
+        $metadata = new Metadata();
+
+        expect($metadata->tags)->toBe([]);
+    });
+
+    it('allows setting tags', function () {
+        $metadata = new Metadata();
+        $metadata->tags = ['smoke', 'regression'];
+
+        expect($metadata->tags)->toBe(['smoke', 'regression']);
+    });
+
 });

--- a/tests/Unit/NullQaseReporterTest.php
+++ b/tests/Unit/NullQaseReporterTest.php
@@ -94,6 +94,13 @@ describe('NullQaseReporter', function () {
             expect($result)->toBe($reporter);
         });
 
+        it('tag returns self', function () {
+            $reporter = new NullQaseReporter();
+            $result = $reporter->tag('smoke');
+
+            expect($result)->toBe($reporter);
+        });
+
     });
 
     describe('step callback execution', function () {
@@ -136,7 +143,8 @@ describe('NullQaseReporter', function () {
                 ->parameter('browser', 'chrome')
                 ->comment('Comment')
                 ->attach('/path/to/file')
-                ->step('Test step');
+                ->step('Test step')
+                ->tag('smoke');
 
             expect($result)->toBe($reporter);
         });

--- a/tests/Unit/TagsFixture.php
+++ b/tests/Unit/TagsFixture.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use Qase\PestReporter\Attributes\Tags;
+
+class TagsFixture
+{
+    #[Tags('smoke', 'regression')]
+    public function testWithTags(): void {}
+
+    public function testWithoutTags(): void {}
+}

--- a/tests/Unit/TagsTest.php
+++ b/tests/Unit/TagsTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use Qase\PestReporter\Attributes\AttributeParser;
+use Qase\PestReporter\Attributes\AttributeReader;
+use Qase\PestReporter\NullQaseReporter;
+use Qase\PhpCommons\Loggers\Logger;
+
+class TagsTest extends TestCase
+{
+    private AttributeParser $parser;
+
+    protected function setUp(): void
+    {
+        $this->parser = new AttributeParser(new Logger(), new AttributeReader());
+    }
+
+    public function testParseTagsFromAttribute(): void
+    {
+        $metadata = $this->parser->parseAttribute(TagsFixture::class, 'testWithTags');
+        $this->assertSame(['smoke', 'regression'], $metadata->tags);
+    }
+
+    public function testMergeClassAndMethodTags(): void
+    {
+        $metadata = $this->parser->parseAttribute(ClassTagsFixture::class, 'testWithMethodTags');
+        $this->assertSame(['smoke', 'regression'], $metadata->tags);
+    }
+
+    public function testEmptyTags(): void
+    {
+        $metadata = $this->parser->parseAttribute(TagsFixture::class, 'testWithoutTags');
+        $this->assertSame([], $metadata->tags);
+    }
+
+    public function testNullReporterTag(): void
+    {
+        $null = new NullQaseReporter();
+        $result = $null->tag('smoke', 'regression');
+        $this->assertSame($null, $result);
+    }
+}


### PR DESCRIPTION
## Summary
- Add `#[Tags('smoke', 'regression')]` attribute (repeatable, class+method)
- Add `qase()->tag('smoke', 'regression')` fluent API method
- Add `Qase::tag('smoke', 'regression')` static facade
- Create docs/usage.md with full documentation
- Update examples, expected YAML, unit tests (4 new + 3 updated)
- Bump version to 1.0.3, depends on php-commons ^2.1.18

## Test plan
- [x] Run `composer test` — all 65 tests pass
- [ ] Verify attribute-based tags extraction
- [ ] Verify fluent API tag() method works
- [ ] Verify NullQaseReporter.tag() returns self
- [ ] Review docs/usage.md